### PR TITLE
Fix "add/remove %itemtypes% to/from %inventory/players%" to not clear some slots

### DIFF
--- a/src/main/java/ch/njol/skript/aliases/ItemType.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemType.java
@@ -764,6 +764,7 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 	 */
 	public boolean removeFrom(final Inventory invi) {
 		ItemStack[] buf = invi.getContents();
+		/* This was causing issues with clearing some slots (armor, offhand and last slot)
 		// uses an array of size 36. some unknown bug with bukkit
 		if (buf.length > 36) {
 			ItemStack[] tBuf = buf.clone();
@@ -772,6 +773,7 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 				buf[i] = tBuf[i];
 			}
 		}
+		*/
 		final ItemStack[] armour = invi instanceof PlayerInventory ? ((PlayerInventory) invi).getArmorContents() : null;
 		
 		@SuppressWarnings("unchecked")

--- a/src/main/java/ch/njol/skript/aliases/ItemType.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemType.java
@@ -874,6 +874,7 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 		if (buf == null)
 			return false;
 		// uses an array of size 36. some unknown bug with bukkit
+		/* This was causing issues with clearing some slots (armor, offhand and last slot)
 		if (buf.length > 36) {
 			ItemStack[] tBuf = buf.clone();
 			buf = new ItemStack[35];
@@ -881,6 +882,7 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 				buf[i] = tBuf[i];
 			}
 		}
+		*/
 		final boolean b = addTo(buf);
 		invi.setContents(buf);
 		return b;

--- a/src/main/java/ch/njol/skript/classes/data/DefaultChangers.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultChangers.java
@@ -216,22 +216,14 @@ public class DefaultChangers {
 						//$FALL-THROUGH$
 					case ADD:
 						assert delta != null;
-						if(delta instanceof ItemStack[]) {
-							/* This was causing issues with clearing some slots (armor, offhand and last slot)
-							ItemStack[] items = (ItemStack[]) delta;
-							if(items.length > 36) {
-								return;
-							}
-							*/
-							for (final Object d : delta) {
-								if (d instanceof Inventory) {
-									for (final ItemStack i : (Inventory) d) {
-										if (i != null)
-											invi.addItem(i);
-									}
-								} else {
-									((ItemType) d).addTo(invi);
+						for (final Object d : delta) {
+							if (d instanceof Inventory) {
+								for (final ItemStack i : (Inventory) d) {
+									if (i != null)
+										invi.addItem(i);
 								}
+							} else {
+								((ItemType) d).addTo(invi);
 							}
 						}
 						break;

--- a/src/main/java/ch/njol/skript/classes/data/DefaultChangers.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultChangers.java
@@ -217,10 +217,12 @@ public class DefaultChangers {
 					case ADD:
 						assert delta != null;
 						if(delta instanceof ItemStack[]) {
+							/* This was causing issues with clearing some slots (armor, offhand and last slot)
 							ItemStack[] items = (ItemStack[]) delta;
 							if(items.length > 36) {
 								return;
 							}
+							*/
 							for (final Object d : delta) {
 								if (d instanceof Inventory) {
 									for (final ItemStack i : (Inventory) d) {

--- a/src/main/java/ch/njol/skript/registrations/Classes.java
+++ b/src/main/java/ch/njol/skript/registrations/Classes.java
@@ -84,21 +84,12 @@ public abstract class Classes {
 	 */
 	public static <T> void registerClass(final ClassInfo<T> info) {
 		Skript.checkAcceptRegistrations();
-		if (classInfosByCodeName.containsKey(info.getCodeName())) {
-			Skript.warning("Can't register " + info.getC().getName() + " with the code name " + info.getCodeName() + " because that name is already used by " + classInfosByCodeName.get(info.getCodeName()));
-			return;
-//			throw new IllegalArgumentException("Can't register " + info.getC().getName() + " with the code name " + info.getCodeName() + " because that name is already used by " + classInfosByCodeName.get(info.getCodeName()));
-		}
-		if (exactClassInfos.containsKey(info.getC())) {
-			Skript.warning("Can't register the class info " + info.getCodeName() + " because the class " + info.getC().getName() + " is already registered");
-			return;
-//			throw new IllegalArgumentException("Can't register the class info " + info.getCodeName() + " because the class " + info.getC().getName() + " is already registered");
-		}
-		if (info.getCodeName().length() > DatabaseStorage.MAX_CLASS_CODENAME_LENGTH) {
-			Skript.warning("The codename '" + info.getCodeName() + "' is too long to be saved in a database, the maximum length allowed is " + DatabaseStorage.MAX_CLASS_CODENAME_LENGTH);
-			return;
-//			throw new IllegalArgumentException("The codename '" + info.getCodeName() + "' is too long to be saved in a database, the maximum length allowed is " + DatabaseStorage.MAX_CLASS_CODENAME_LENGTH);
-		}
+		if (classInfosByCodeName.containsKey(info.getCodeName()))
+			throw new IllegalArgumentException("Can't register " + info.getC().getName() + " with the code name " + info.getCodeName() + " because that name is already used by " + classInfosByCodeName.get(info.getCodeName()));
+		if (exactClassInfos.containsKey(info.getC()))
+			throw new IllegalArgumentException("Can't register the class info " + info.getCodeName() + " because the class " + info.getC().getName() + " is already registered");
+		if (info.getCodeName().length() > DatabaseStorage.MAX_CLASS_CODENAME_LENGTH)
+			throw new IllegalArgumentException("The codename '" + info.getCodeName() + "' is too long to be saved in a database, the maximum length allowed is " + DatabaseStorage.MAX_CLASS_CODENAME_LENGTH);
 		exactClassInfos.put(info.getC(), info);
 		classInfosByCodeName.put(info.getCodeName(), info);
 		tempClassInfos.add(info);


### PR DESCRIPTION
I've made some fixes to the effects "add %itemtypes% to %inventory/players%" and "remove %itemtypes% from %inventory/players%".

These effects were clearing the last slots of a player/inventory, such as the last slot, offhand and armor.

Just out of curiosity: why were you using an array of 36 itemstacks? What was the bug you mentioned?
